### PR TITLE
_view_ modifier

### DIFF
--- a/sol/BPool.sol
+++ b/sol/BPool.sol
@@ -48,6 +48,11 @@ contract BPool is BBronze, BToken, BMath
         _mutex = false;
     }
 
+    modifier _view_() {
+        require( !_mutex, ERR_REENTRY);
+        _;
+    }
+
     bool                      _mutex;
 
     bool                      _public;
@@ -95,7 +100,9 @@ contract BPool is BBronze, BToken, BMath
     }
 
     function getWeight(address token)
-      public view returns (uint) {
+      public view
+      _view_
+      returns (uint) {
         return _records[token].weight;
     }
 


### PR DESCRIPTION
`_view_` checks the mutex without setting it, allowing getters to be typed as `view` while still being protected

This PR shows just one example getter protected with `_view_`. Each function needs to be reviewed to determine if the state is set during calls that can re-enter.

Alternatively, we can lock everything with no consequences except a small gas cost (state storage costs are determined at the end of a call and are only expensive if the state changes)