### PR TITLE
change limit names to min max

### DIFF
--- a/contracts/BMath.sol
+++ b/contracts/BMath.sol
@@ -290,11 +290,11 @@ contract BMath is BBronze, BConst, BNum
     // _calc_SingleOutGivenPoolIn                                                                //
     // tAo = tokenAmountOut            /      /                                             \\   //
     // bO = tokenBalanceOut           /      // pS - (pAi * (1 - eF)) \     /    1    \      \\  //
-    // pAi = poolAmountIn            | bO - || ----------------------- | ^ | --------- | * b0 || // 
+    // pAi = poolAmountIn            | bO - || ----------------------- | ^ | --------- | * b0 || //
     // ps = poolSupply                \      \\          pS           /     \(wO / tW)/      //  //
-    // wI = tokenWeightIn      tAo =   \      \                                             //   //                                              
+    // wI = tokenWeightIn      tAo =   \      \                                             //   //
     // tW = totalWeight                    /     /      wO \       \                             //
-    // sF = swapFee                    *  | 1 - |  1 - ---- | * sF  |                            //          
+    // sF = swapFee                    *  | 1 - |  1 - ---- | * sF  |                            //
     // eF = exitFee                        \     \      tW /       /                             //
     **********************************************************************************************/
     function _calc_SingleOutGivenPoolIn(
@@ -330,12 +330,12 @@ contract BMath is BBronze, BConst, BNum
 
     /**********************************************************************************************
     // _calc_PoolInGivenSingleOut                                                                //
-    // pAi = poolAmountIn               // /               tAo             \\     / wO \     \   //                \\   //
+    // pAi = poolAmountIn               // /               tAo             \\     / wO \     \   //
     // bO = tokenBalanceOut            // | bO - -------------------------- |\   | ---- |     \  //
     // tAo = tokenAmountOut      pS - ||   \     1 - ((1 - (tO / tW)) * sF)/  | ^ \ tW /  * pS | //
     // ps = poolSupply                 \\ -----------------------------------/                /  //
     // wO = tokenWeightOut  pAi =       \\               bO                 /                /   //
-    // tW = totalWeight           -------------------------------------------------------------  //    
+    // tW = totalWeight           -------------------------------------------------------------  //
     // sF = swapFee                                        ( 1 - eF )                            //
     // eF = exitFee                                                                              //
     **********************************************************************************************/

--- a/contracts/BPool.sol
+++ b/contracts/BPool.sol
@@ -482,7 +482,7 @@ contract BPool is BBronze, BToken, BMath
     }
 
 
-    function swap_ExactMarginalPrice(address tokenIn, uint limitAmountIn, address tokenOut, uint limitAmountOut, uint marginalPrice)
+    function swap_ExactMarginalPrice(address tokenIn, uint maxAmountIn, address tokenOut, uint minAmountOut, uint marginalPrice)
         external
         _logs_
         _lock_
@@ -503,8 +503,8 @@ contract BPool is BBronze, BToken, BMath
         tokenAmountIn = _calc_InGivenPrice( I.balance, I.denorm, O.balance, O.denorm, _totalWeight, marginalPrice, _swapFee );
         tokenAmountOut = _calc_OutGivenIn( I.balance, I.denorm, O.balance, O.denorm, tokenAmountIn, _swapFee );
 
-        require( tokenAmountIn <= limitAmountIn, ERR_LIMIT_IN);
-        require( tokenAmountOut >= limitAmountOut, ERR_LIMIT_OUT);
+        require( tokenAmountIn <= maxAmountIn, ERR_LIMIT_IN);
+        require( tokenAmountOut >= minAmountOut, ERR_LIMIT_OUT);
 
         I.balance = badd(I.balance, tokenAmountIn);
         O.balance = bsub(O.balance, tokenAmountOut);


### PR DESCRIPTION
- Removes extra spaces on formulas in BMath
- Changes limitAmountIn and limitAmountOut to `maxAmountIn` and `minAmountOut`