### PR TITLE
Fix formula in calcPoolInGivenSingleOut comment block

### DIFF
--- a/contracts/BMath.sol
+++ b/contracts/BMath.sol
@@ -227,7 +227,7 @@ contract BMath is BBronze, BConst, BNum {
     // calcPoolInGivenSingleOut                                                                  //
     // pAi = poolAmountIn               // /               tAo             \\     / wO \     \   //
     // bO = tokenBalanceOut            // | bO - -------------------------- |\   | ---- |     \  //
-    // tAo = tokenAmountOut      pS - ||   \     1 - ((1 - (tO / tW)) * sF)/  | ^ \ tW /  * pS | //
+    // tAo = tokenAmountOut      pS - ||   \     1 - ((1 - (wO / tW)) * sF)/  | ^ \ tW /  * pS | //
     // ps = poolSupply                 \\ -----------------------------------/                /  //
     // wO = tokenWeightOut  pAi =       \\               bO                 /                /   //
     // tW = totalWeight           -------------------------------------------------------------  //


### PR DESCRIPTION
Corrected the token weight variable in the calcPoolInGivenSingleOut function's comment block from (tO / tW) to the correct (wO / tW). This change ensures that the documentation accurately reflects the calculation based on the token's weight (wO) relative to the total weight (tW), rather than an undefined variable (tO).